### PR TITLE
Use `enchive-program-name` when encrypting file.

### DIFF
--- a/enchive-mode.el
+++ b/enchive-mode.el
@@ -31,7 +31,7 @@
              (list file (buffer-size))))
           ((eq operation 'write-region)
            (call-process-region (nth 0 args) (nth 1 args)
-                                "enchive" nil nil nil
+				enchive-program-name nil nil nil
                                 "archive" "/dev/stdin" (nth 2 args)))
           ((apply operation args)))))
 


### PR DESCRIPTION
Discussed in #11. The call to do the decryption was fixed in https://github.com/skeeto/enchive/commit/12d9ae961386917c9d2ddbc5be9f1c243fa95503 but it seems the call to do the encryption wasn't.