### PR TITLE
Choose major mode based on file name without '.enchive' (#13)

### DIFF
--- a/enchive-mode.el
+++ b/enchive-mode.el
@@ -16,8 +16,11 @@
 (defcustom enchive-program-name "enchive"
   "Path to the locally installed enchive binary.")
 
-(defvar enchive-handler-entry (cons "\\.enchive$" #'enchive-file-handler)
+(defvar enchive-handler-entry (cons "\\.enchive\\'" #'enchive-file-handler)
   "Entry for `enchive-mode' in `file-name-handler-alist'.")
+
+(defvar enchive-auto-mode-entry (list "\\.enchive\\'" nil 'enchive)
+  "Entry for `enchive-mode' in `auto-mode-alist'.")
 
 (defun enchive-file-handler (operation &rest args)
   "Handler for `file-name-handler-alist' for automatic encrypt/decrypt."
@@ -41,9 +44,13 @@
   :global t
   (setf file-name-handler-alist
         (delq enchive-handler-entry file-name-handler-alist))
-  (if enchive-mode
-      (setf file-name-handler-alist
-            (cons enchive-handler-entry file-name-handler-alist))))
+  (setf auto-mode-alist
+        (delq enchive-auto-mode-entry auto-mode-alist))
+  (when enchive-mode
+    (setf file-name-handler-alist
+          (cons enchive-handler-entry file-name-handler-alist))
+    (setf auto-mode-alist
+          (cons enchive-auto-mode-entry auto-mode-alist))))
 
 (provide 'enchive-mode)
 


### PR DESCRIPTION
This should fix issue #13 (just tested it with an org-mode file), for which there is (as usual) already a mechanism in Emacs :)

`auto-mode-alist` can have an entry that only strips off the extension and then redoes the search.  I add/delq such an entry analogous with the handler entry itself.

Minor change in the latter's regexp: "\\\\'" at the end is better than "\\\\$", as it also works with multi-line file names (which are uncommon but legal).