### PR TITLE
Fix 'make install': correct permissions for executable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ clean:
 install: enchive enchive.1
 	mkdir -p $(DESTDIR)$(PREFIX)/bin
 	mkdir -p $(DESTDIR)$(PREFIX)/share/man/man1
-	cp -f enchive $(DESTDIR)$(PREFIX)/bin
+	install -m 755 enchive $(DESTDIR)$(PREFIX)/bin
 	gzip < enchive.1 > $(DESTDIR)$(PREFIX)/share/man/man1/enchive.1.gz
 
 uninstall:


### PR DESCRIPTION
This makes a big difference if you do `sudo make install` and, eg, have a user umask of 0077.  The exectuable will have useless permissions of 0700 then.

I realize that `install` is not POSIX.  If that's a concern, I'll happily change the PR to do the chmod manually, if you prefer.